### PR TITLE
fix _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,8 +12,8 @@ repo: https://github.com/username/username.github.io
 # author settings
 
 author:
-  name: Place Holder
-  email: username@domain.com
+name: Place Holder
+email: username@domain.com
 photo: /assets/jpg/photo.jpg
 
 # social media links


### PR DESCRIPTION
I was trying to use the docker image and when I stopped trying to run locally, I've realized that the issue was within the tabbing before name and email. This causes syntax error whilst trying to run the command:  bundle exec jekyll serve 

or when trying to run a docker image